### PR TITLE
Make quotes span full length in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ After starting the development server.
 * **Is it a original idea?**
 
 > Nowadays, Almost idea is mixing. The original idea was inspired by a guy in HN-Show I've seen in a couple months ago. It's just a tool to generate a photo after dragging manually my original picture. It has lack of capability.
-
+>
 > I'm a lazy guy, I'd something could do it automatically every time. Ultimately, I came up with this idea.
 
 * **Where is the Backend side?**
@@ -96,7 +96,7 @@ After starting the development server.
 * **Why do you choose RxSwift + MVVM?**
 
 > I have solid experience when working with RxSwift + MVVM for a couple projects on Production. I'm so happy when writing concise, elegant Observable, Driver,... rather than clumsy functions with tons of nested-callbacks.
-
+>
 > If something makes me happy, I will follow it. Simple enough 😂
 
 * **Is this app built with Swift?**
@@ -106,45 +106,44 @@ After starting the development server.
 * **Why is it an OSS?**
 
 > The source code is a trash if keep it in your inventory forever. I'd contribute back to the dev community when I have an opportunity.
-
+>
 > The best way is publishing your source code 👨‍💻.
 
 * **Why is 18th century art?**
 
 > Every time I have a short trip to an overseas country, I often spent 1 or 2 days to visit all famous art museum. I could stand for an hour to look at the detail, the scrape from those old oil photo. Individual traits could represent the history, the effort, the dream from original authors.
-
+>
 > I realize I fall in love with the 18th art somehow 🤣
-
+>
 > Then I come up with the idea, why don't we bring it to everybody, who has the same passion as me.
-
-> Let imagine, every day, when I open my laptop at 9 AM, I can see the best photo of this day, with detail information, history, and the author.
-That would be amazing 😱
-
+>
+> Let imagine, every day, when I open my laptop at 9 AM, I can see the best photo of this day, with detail information, history, and the author. That would be amazing 😱
+>
 > Without considering, I start to develop the macOS app as well as the [Artify-Core](https://github.com/NghiaTranUIT/artify-core), which is written by Golang.
-
+>
 > All of the art pictures will be hand-picked by me and my best girlfriend. Hope you enjoy it 😍
 
 * **How does Artify generate the beautify wallpaper?**
 
 > **[DR;TL]**
-
+>
 > 1. Determine the golden size, which relies on your current screen size. It makes sure every generated wallpaper is as nice as possible.
 > 2. Draw this image with the desired size in the middle
 > 3. Draw shadow
 > 4. Scale the background with "aspect to fill" mode
 > 5. Apply Gaussian algorithm
 > 6. Combine everything and cached locally.
-
+>
 > **[Detail implementation]**
-
+>
 > Here is the [algorithm](https://github.com/NghiaTranUIT/artify-macos/blob/master/artify-core/artify-core/Algorithm/Gaussian/GaussianAlgorithm.swift)
 
 * **Where does the Artify's resource come from?**
 
 > Every art pictures are hand-picked from [WikiArt](https://www.wikiart.org).
-
+>
 > If you wonder how I collect the data. Here is my partner, [Spider Man](https://github.com/NghiaTranUIT/artify-core/blob/master/scripts/spider.ruby), which is a Ruby script.
-
+>
 > The conjunction of [Nokogiri](http://www.nokogiri.org) and [Watir](http://watir.com) are perfect for this scenario. Indeed,I'm a lazy man, I don't want to collect data like a manual labor 😅.
 
 * **What are the tough problems, which you confronts when developing this project?**
@@ -156,6 +155,7 @@ That would be amazing 😱
 > Defintely, I appreciate your effort to become a contributor. Clone the project and setup your workspace. Happy coding guys 🚢
 
 * **Do you have personal blog?**
+
 > Yes, I often write blog at [My lab](www.nghiatran.me) 👨‍🍳
 
 * **How do I contact you?**


### PR DESCRIPTION
Not sure if you want this or not, so feel free to just close the PR.

It changes the quotations to span the full length of the text, instead of being one chunk per paragraph:

<img width="286" alt="screen shot 2018-06-26 at 23 40 14" src="https://user-images.githubusercontent.com/189580/41941051-1f1459e2-799b-11e8-9e96-2b79734befd3.png">

Thanks for an awesome project!